### PR TITLE
パフェ投稿機能のデプロイ後の修正

### DIFF
--- a/app/controllers/parfaits_controller.rb
+++ b/app/controllers/parfaits_controller.rb
@@ -1,4 +1,5 @@
 class ParfaitsController < ApplicationController
+  before_action :authenticate_user!, except: %i[index show]
   def index
     @parfaits = Parfait.includes(:shop).order(created_at: :desc)
   end
@@ -40,7 +41,7 @@ class ParfaitsController < ApplicationController
   def destroy
     load_parfait
     @parfait.destroy!
-    redirect_to shops_path(@parfait.shop), success: '削除に成功しました'
+    redirect_to parfaits_path, success: '削除に成功しました'
   end
 
   private

--- a/app/views/parfaits/index.html.erb
+++ b/app/views/parfaits/index.html.erb
@@ -15,7 +15,7 @@
                   <%= link_to edit_parfait_path(parfait), id: "button-edit-#{parfait.id}" do %>
                     <i class='bi bi-pencil-fill'></i>
                   <% end %>
-                  <%= link_to '#', id: "button-delete-#{parfait.id}", data: { turbo_method: :delete, turbo_confirm: t('defaults.delete_confirm') } do %>
+                  <%= link_to parfait_path(parfait), id: "button-delete-#{parfait.id}", data: { turbo_method: :delete, turbo_confirm: t('defaults.delete_confirm') } do %>
                     <i class="bi bi-trash-fill"></i>
                   <% end %>
                 </div>


### PR DESCRIPTION
## 概要
パフェ投稿機能のデプロイ後の修正

以下の機能を追加
- パフェ一覧からもパフェを削除できるようにした
- ログインユーザーにしかパフェの投稿・編集・削除ができないようにした