### PR TITLE
14 resize

### DIFF
--- a/app/forms/shop_must_form.rb
+++ b/app/forms/shop_must_form.rb
@@ -92,6 +92,7 @@ class ShopMustForm
     end
     rescue ActiveRecord::RecordInvalid => e
       Rails.logger.error("Failed to save shop: #{e.message}")
+      Rails.logger.error(e.backtrace.join("\n"))
       false
   end
 

--- a/app/forms/shop_must_form.rb
+++ b/app/forms/shop_must_form.rb
@@ -1,3 +1,5 @@
+require 'open-uri'
+
 class ShopMustForm
   include ActiveModel::Model
   include ActiveModel::Attributes

--- a/app/forms/shop_must_form.rb
+++ b/app/forms/shop_must_form.rb
@@ -51,13 +51,8 @@ class ShopMustForm
       # self.shop_image = nilにしたのはインスタンス変数の値は残るので、クリアするため
 
       if shop_image.present?
-        resized_image = resize_image_dpi(shop_image)
         shop.shop_image.purge if shop.persisted? && shop.shop_image.attached?
-        shop.shop_image.attach(
-          io: resized_image,
-          filename: "#{File.basename(shop_image.original_filename, '.*')}.jpg",
-          content_type: 'image/jpg'
-        )
+        shop.shop_image.attach
       end
     end
     rescue ActiveRecord::RecordInvalid => e

--- a/app/forms/shop_must_form.rb
+++ b/app/forms/shop_must_form.rb
@@ -52,7 +52,7 @@ class ShopMustForm
 
       if shop_image.present?
         shop.shop_image.purge if shop.persisted? && shop.shop_image.attached?
-        shop.shop_image.attach
+        shop.shop_image.attach(shop_image)
       end
     end
     rescue ActiveRecord::RecordInvalid => e
@@ -100,15 +100,5 @@ class ShopMustForm
     shop_business_hours.split("\n")
   end
 
-  def resize_image_dpi(uploaded_file)
-    image = MiniMagick::Image.read(uploaded_file.tempfile)
-    image.resize 'x1350'     # 高さを1350pxにリサイズ
-    image.density '96'       # 解像度設定（DPI）
-  
-    tempfile_jpg = Tempfile.new('resized')
-    image.write(tempfile_jpg.path)
-    tempfile_jpg.rewind
-    tempfile_jpg
-  end
-  
+
 end

--- a/app/forms/shop_must_form.rb
+++ b/app/forms/shop_must_form.rb
@@ -70,7 +70,7 @@ class ShopMustForm
       if shop_image.present?
         if Rails.env.production?
           begin
-            uploaded = Cloudinary::Uploader.upload(shop_image, transformation: { height: 1350, crop: :limit, format: 'jpg' })
+            uploaded = Cloudinary::Uploader.upload(shop_image, transformation: { height: 1350, crop: :limit, format: 'jpg', quality: 'auto' })
             Rails.logger.info "Cloudinary upload successful: #{uploaded['secure_url']}"
             
             # Cloudinaryのpublic_idをActiveStorageのkeyとして設定
@@ -81,7 +81,6 @@ class ShopMustForm
               io: URI.open(uploaded['secure_url']), # CloudinaryのURLを取得
               filename: "#{File.basename(shop_image.original_filename, '.*')}.jpg", 
               content_type: 'image/jpg',
-              quality: 'auto'
             )
             
             shop.shop_image.key = uploaded['public_id']

--- a/app/models/shop.rb
+++ b/app/models/shop.rb
@@ -29,7 +29,7 @@ class Shop < ApplicationRecord
 
   def image_as_thumbnail
     return unless shop_image.content_type.in?(%w[image/jpeg image/png])
-    shop_image.variant(resize_to_limit: [400, 500]).processed
+    shop_image.variant(resize_to_limit: [400, 500])
   end
 
   def prefecture_name

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -8,7 +8,9 @@ local:
 
 cloudinary:
   service: Cloudinary
-
+  cloud_name: <%= Rails.application.credentials.dig(:cloudinary, :cloud_name) %>
+  api_key:    <%= Rails.application.credentials.dig(:cloudinary, :api_key) %>
+  api_secret: <%= Rails.application.credentials.dig(:cloudinary, :api_secret) %>
 # Use bin/rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)
 # amazon:
 #   service: S3

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -8,9 +8,7 @@ local:
 
 cloudinary:
   service: Cloudinary
-  cloud_name: <%= Rails.application.credentials.dig(:cloudinary, :cloud_name) %>
-  api_key:    <%= Rails.application.credentials.dig(:cloudinary, :api_key) %>
-  api_secret: <%= Rails.application.credentials.dig(:cloudinary, :api_secret) %>
+
 # Use bin/rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)
 # amazon:
 #   service: S3


### PR DESCRIPTION
## 概要
画像をリサイズして保存するためにコントローラとフォームオブジェクトに変更を加えた

## なぜこの変更をするのか
cloudinaryの無料プランでDBに保存するのに画像サイズを小さくしたいが、
スマホの画像をアップするとなると重たくなることが想定できるため

## 比較
- 以前のsave時のコードの状態。リサイズしないで保存する状態ですとheroku環境でも保存ができました。
[![Image from Gyazo](https://i.gyazo.com/34dcee6169b7883dadd399d7fa7b5d12.png)](https://gyazo.com/34dcee6169b7883dadd399d7fa7b5d12)

- 現在の状態。こちらはローカル環境ですとリサイズして保存ができましたが、heroku環境だと上手くいきません。
[![Image from Gyazo](https://i.gyazo.com/44d08e2841ccc2c98891c9eb565f5db4.png)](https://gyazo.com/44d08e2841ccc2c98891c9eb565f5db4)
