### PR TITLE
画像アップ機能のデプロイまで

### DIFF
--- a/app/controllers/parfaits_controller.rb
+++ b/app/controllers/parfaits_controller.rb
@@ -21,15 +21,7 @@ class ParfaitsController < ApplicationController
     @parfait = Parfait.new(parfait_params)
 
     if params[:parfait][:parfait_image].present?
-      resized_images = resize_image_set_dpi(params[:parfait][:parfait_image])
-      original_filename_base = File.basename(params[:parfait][:parfait_image].original_filename, ".*")
-
-      @parfait.parfait_image.attach(
-        io: resized_images,
-        filename: "#{original_filename_base}.jpg",
-        # ここでcontent_typeを指定しないと名前は.jpgの拡張子が付いているけどデータはpngみたいなことが起こる可能性がある
-        content_type: 'image/jpg'
-      )
+      @parfait.parfait_image.attach(params[:parfait][:parfait_image])
     end
 
     if @parfait.save
@@ -53,15 +45,7 @@ class ParfaitsController < ApplicationController
     end
 
     if params[:parfait][:parfait_image].present?
-      resized_images = resize_image_set_dpi(params[:parfait][:parfait_image])
-      original_filename_base = File.basename(params[:parfait][:parfait_image].original_filename, ".*")
-
-      @parfait.parfait_image.attach(
-        io: resized_images,
-        filename: "#{original_filename_base}.jpg",
-        # ここでcontent_typeを指定しないと名前は.jpgの拡張子が付いているけどデータはpngみたいなことが起こる可能性がある
-        content_type: 'image/jpg'
-      )
+      @parfait.parfait_image.attach(params[:parfait][:parfait_image])
     end
 
     if @parfait.update(parfait_params.except(:remove_parfait_image))
@@ -86,24 +70,6 @@ class ParfaitsController < ApplicationController
 
   def load_parfait
     @parfait = Parfait.includes(:shop).find(params[:id])
-  end
-
-  def resize_image_set_dpi(uploaded_file)
-    # uploaded_file.tempfileから画像を読み込み、MiniMagickオブジェクトとして扱う
-    image = MiniMagick::Image.read(uploaded_file.tempfile)
-    # 画像の縦幅を1350ピクセルにリサイズ
-    image.resize 'x1350'
-    # 画像の解像度を96 DPIに設定
-    image.density '96'
-
-    # 一時ファイルを作成
-    tempfile_jpg = Tempfile.new('resized')
-    # 変更された画像を一時ファイルに書き込み（ここで画像が指定されたリサイズと解像度で保存される）
-    image.write (tempfile_jpg.path)
-    # ファイルを読み込む準備
-    tempfile_jpg.rewind
-    # 一時ファイルを呼び出す
-    tempfile_jpg
   end
 
 end

--- a/app/controllers/parfaits_controller.rb
+++ b/app/controllers/parfaits_controller.rb
@@ -19,19 +19,28 @@ class ParfaitsController < ApplicationController
   
   def create
     @parfait = Parfait.new(parfait_params)
-
-    if params[:parfait][:parfait_image].present?
-      @parfait.parfait_image.attach(params[:parfait][:parfait_image])
-    end
-
+  
+    # まずレコードを保存してから画像を添付する
     if @parfait.save
+      # 複数の画像を添付
+      if params[:parfait][:parfait_image].present?
+        params[:parfait][:parfait_image].each do |image|
+
+          next if image.blank?
+
+          @parfait.parfait_image.attach(image)
+        end
+      end
+      @parfait.save # 再度保存することで画像をデータベースに関連付け
+  
       redirect_to @parfait, success: 'パフェが登録されました'
     else
-      flash.now[:danger] = t('defaults.flash_message.not_created', item: Shop.model_name.human)
+      Rails.logger.debug "Parfait errors: #{@parfait.errors.full_messages}"
+      flash.now[:danger] = t('defaults.flash_message.not_created', item: Parfait.model_name.human)
       render :new, status: :unprocessable_entity
     end
   end
-
+  
   def edit
     load_parfait
 

--- a/app/controllers/parfaits_controller.rb
+++ b/app/controllers/parfaits_controller.rb
@@ -22,17 +22,10 @@ class ParfaitsController < ApplicationController
   
     # まずレコードを保存してから画像を添付する
     if @parfait.save
-      # 複数の画像を添付
       if params[:parfait][:parfait_image].present?
-        params[:parfait][:parfait_image].each do |image|
-
-          next if image.blank?
-
-          @parfait.parfait_image.attach(image)
-        end
+        @parfait.parfait_image.attach(params[:parfait][:parfait_image])
+        @parfait.save # 再度保存することで画像をデータベースに関連付け
       end
-      @parfait.save # 再度保存することで画像をデータベースに関連付け
-  
       redirect_to @parfait, success: 'パフェが登録されました'
     else
       Rails.logger.debug "Parfait errors: #{@parfait.errors.full_messages}"
@@ -41,6 +34,7 @@ class ParfaitsController < ApplicationController
     end
   end
   
+
   def edit
     load_parfait
 

--- a/app/controllers/parfaits_controller.rb
+++ b/app/controllers/parfaits_controller.rb
@@ -39,22 +39,30 @@ class ParfaitsController < ApplicationController
 
   def update
     load_parfait
-
-    if params[:parfait][:remove_parfait_image] == '1'
-      @parfait.parfait_image.purge if @parfait.parfait_image.attached?
-    end
-
-    if params[:parfait][:parfait_image].present?
-      @parfait.parfait_image.attach(params[:parfait][:parfait_image])
-    end
-
-    if @parfait.update(parfait_params.except(:remove_parfait_image))
+  
+    # まず、普通のテキスト情報だけ更新する
+    if @parfait.update(parfait_params)
+      
+      # もし画像を消したいって指示があったら、ここで削除する
+      if params[:parfait][:remove_parfait_image] == '1'
+        @parfait.parfait_image.purge if @parfait.parfait_image.attached?
+      end
+  
+      # 新しい画像がアップロードされてたら、ここでつけ直す
+      if params[:parfait][:parfait_image].present?
+        # いったん古い画像があれば消してから
+        @parfait.parfait_image.purge if @parfait.parfait_image.attached?
+        # 新しい画像を保存
+        @parfait.parfait_image.attach(params[:parfait][:parfait_image])
+      end
+  
       redirect_to @parfait, success: 'パフェが更新されました', status: :see_other
     else
       flash.now[:danger] = "パフェを更新できませんでした"
       render :edit, status: :unprocessable_entity
     end
   end
+  
 
   def destroy
     load_parfait

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -14,18 +14,8 @@ class ReviewsController < ApplicationController
     @review = current_user.reviews.build(review_params)
 
     if params[:review][:review_images].present?
-      params[:review][:review_images].each do |image|
-        resized_image = resize_image_set_dpi(image)
-        
-        # オリジナルファイル名から拡張子を除去したベース名を取得
-        original_filename_base = File.basename(image.original_filename, ".*")
-        
-        # 圧縮された画像をActiveStorageに添付
-        @review.review_images.attach(
-          io: resized_image,
-          filename: "#{original_filename_base}.jpg",
-          content_type: 'image/jpg'
-        )
+      params[:review][:review_images].reject(&:blank?).each do |image|
+        @review.review_images.attach(io: image.tempfile, filename: image.original_filename, content_type: image.content_type)
       end
     end
 
@@ -54,20 +44,8 @@ class ReviewsController < ApplicationController
     @review = current_user.reviews.find(params[:id])
 
     if params[:review][:review_images].present?
-      params[:review][:review_images].each do |image|
-        next if image.blank?
-
-        resized_image = resize_image_set_dpi(image)
-        
-        # オリジナルファイル名から拡張子を除去したベース名を取得
-        original_filename_base = File.basename(image.original_filename, ".*")
-        
-        # 圧縮された画像をActiveStorageに添付
-        @review.review_images.attach(
-          io: resized_image,
-          filename: "#{original_filename_base}.jpg",
-          content_type: 'image/jpg'
-        )
+      params[:review][:review_images].reject(&:blank?).each do |image|
+        @review.review_images.attach(io: image.tempfile, filename: image.original_filename, content_type: image.content_type)
       end
     end
 
@@ -103,21 +81,4 @@ class ReviewsController < ApplicationController
     @review = Review.includes(:user, parfait: :shop).find(params[:id])
   end
 
-  def resize_image_set_dpi(uploaded_file)
-    # uploaded_file.tempfileから画像を読み込み、MiniMagickオブジェクトとして扱う
-    image = MiniMagick::Image.read(uploaded_file.tempfile)
-    # 画像の縦幅を1350ピクセルにリサイズ
-    image.resize 'x1350'
-    # 画像の解像度を96 DPIに設定
-    image.density '96'
-
-    # 一時ファイルを作成
-    tempfile_jpg = Tempfile.new('resized')
-    # 変更された画像を一時ファイルに書き込み（ここで画像が指定されたリサイズと解像度で保存される）
-    image.write (tempfile_jpg.path)
-    # ファイルを読み込む準備
-    tempfile_jpg.rewind
-    # 一時ファイルを呼び出す
-    tempfile_jpg
-  end
 end

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -15,17 +15,9 @@ class ReviewsController < ApplicationController
 
     if params[:review][:review_images].present?
       params[:review][:review_images].each do |image|
-        resized_image = resize_image_set_dpi(image)
-        
-        # オリジナルファイル名から拡張子を除去したベース名を取得
-        original_filename_base = File.basename(image.original_filename, ".*")
         
         # 圧縮された画像をActiveStorageに添付
-        @review.review_images.attach(
-          io: resized_image,
-          filename: "#{original_filename_base}.jpg",
-          content_type: 'image/jpg'
-        )
+        @review.review_images.attach(image)
       end
     end
 
@@ -55,10 +47,7 @@ class ReviewsController < ApplicationController
 
     if params[:review][:review_images].present?
       params[:review][:review_images].each do |image|
-        next if image.blank?
-
-        resized_image = resize_image_set_dpi(image)
-        
+        next if image.blank?        
         # オリジナルファイル名から拡張子を除去したベース名を取得
         original_filename_base = File.basename(image.original_filename, ".*")
         
@@ -103,21 +92,4 @@ class ReviewsController < ApplicationController
     @review = Review.includes(:user, parfait: :shop).find(params[:id])
   end
 
-  def resize_image_set_dpi(uploaded_file)
-    # uploaded_file.tempfileから画像を読み込み、MiniMagickオブジェクトとして扱う
-    image = MiniMagick::Image.read(uploaded_file.tempfile)
-    # 画像の縦幅を1350ピクセルにリサイズ
-    image.resize 'x1350'
-    # 画像の解像度を96 DPIに設定
-    image.density '96'
-
-    # 一時ファイルを作成
-    tempfile_jpg = Tempfile.new('resized')
-    # 変更された画像を一時ファイルに書き込み（ここで画像が指定されたリサイズと解像度で保存される）
-    image.write (tempfile_jpg.path)
-    # ファイルを読み込む準備
-    tempfile_jpg.rewind
-    # 一時ファイルを呼び出す
-    tempfile_jpg
-  end
 end

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -14,8 +14,18 @@ class ReviewsController < ApplicationController
     @review = current_user.reviews.build(review_params)
 
     if params[:review][:review_images].present?
-      params[:review][:review_images].reject(&:blank?).each do |image|
-        @review.review_images.attach(io: image.tempfile, filename: image.original_filename, content_type: image.content_type)
+      params[:review][:review_images].each do |image|
+        resized_image = resize_image_set_dpi(image)
+        
+        # オリジナルファイル名から拡張子を除去したベース名を取得
+        original_filename_base = File.basename(image.original_filename, ".*")
+        
+        # 圧縮された画像をActiveStorageに添付
+        @review.review_images.attach(
+          io: resized_image,
+          filename: "#{original_filename_base}.jpg",
+          content_type: 'image/jpg'
+        )
       end
     end
 
@@ -44,8 +54,20 @@ class ReviewsController < ApplicationController
     @review = current_user.reviews.find(params[:id])
 
     if params[:review][:review_images].present?
-      params[:review][:review_images].reject(&:blank?).each do |image|
-        @review.review_images.attach(io: image.tempfile, filename: image.original_filename, content_type: image.content_type)
+      params[:review][:review_images].each do |image|
+        next if image.blank?
+
+        resized_image = resize_image_set_dpi(image)
+        
+        # オリジナルファイル名から拡張子を除去したベース名を取得
+        original_filename_base = File.basename(image.original_filename, ".*")
+        
+        # 圧縮された画像をActiveStorageに添付
+        @review.review_images.attach(
+          io: resized_image,
+          filename: "#{original_filename_base}.jpg",
+          content_type: 'image/jpg'
+        )
       end
     end
 
@@ -81,4 +103,21 @@ class ReviewsController < ApplicationController
     @review = Review.includes(:user, parfait: :shop).find(params[:id])
   end
 
+  def resize_image_set_dpi(uploaded_file)
+    # uploaded_file.tempfileから画像を読み込み、MiniMagickオブジェクトとして扱う
+    image = MiniMagick::Image.read(uploaded_file.tempfile)
+    # 画像の縦幅を1350ピクセルにリサイズ
+    image.resize 'x1350'
+    # 画像の解像度を96 DPIに設定
+    image.density '96'
+
+    # 一時ファイルを作成
+    tempfile_jpg = Tempfile.new('resized')
+    # 変更された画像を一時ファイルに書き込み（ここで画像が指定されたリサイズと解像度で保存される）
+    image.write (tempfile_jpg.path)
+    # ファイルを読み込む準備
+    tempfile_jpg.rewind
+    # 一時ファイルを呼び出す
+    tempfile_jpg
+  end
 end

--- a/app/forms/shop_must_form.rb
+++ b/app/forms/shop_must_form.rb
@@ -47,77 +47,23 @@ class ShopMustForm
 
       if remove_shop_image == '1'
         if shop.shop_image.attached?
-          # 本番環境ならCloudinaryの画像も削除する
-          if Rails.env.production?
-            begin
-              Cloudinary::Uploader.destroy(shop.cloudinary_public_id) # Cloudinary上の画像を削除
-            rescue => e
-              Rails.logger.warn "Cloudinary削除失敗: #{e.message}"
-            end
-          end
-      
-          # ActiveStorageのデータ削除（Cloudinaryも含めて削除済みの場合も含む）
           shop.shop_image.purge
-          shop.update!(cloudinary_public_id: nil)
-        end
-      
+        end 
         # インスタンス変数の画像もクリア
         self.shop_image = nil
       end
       
       # 新しい画像を保存する処理
       if shop_image.present?
-        if Rails.env.production?
-          begin
-            # 古いCloudinary画像があれば削除（容量節約のため）
-            if shop.cloudinary_public_id.present?
-              Cloudinary::Uploader.destroy(shop.cloudinary_public_id)
-              Rails.logger.info "Old Cloudinary image deleted: #{shop.cloudinary_public_id}"
-            end
-      
-            # Cloudinaryへのアップロードとリサイズの設定
-            uploaded = Cloudinary::Uploader.upload(
-              shop_image, 
-              transformation: { 
-                width: 2000,  # 幅を800pxにリサイズ（必要に応じて変更）
-                height: 2000, # 高さを600pxにリサイズ（必要に応じて変更）
-                crop: :limit, # リサイズ後に画像を切り取る
-                format: 'jpg', # 画像形式をjpgに
-                quality: 'auto' # 自動的に画像品質を調整
-              }
-            )
-      
-            Rails.logger.info "Cloudinary upload successful: #{uploaded['secure_url']}"
-      
-            # shopにcloudinaryのpublic_idを保存
-            shop.update!(cloudinary_public_id: uploaded['public_id'])
-      
-            # ActiveStorageのkeyをCloudinaryのpublic_idに設定
-            shop.shop_image.purge if shop.persisted? && shop.shop_image.attached?
-      
-            # ActiveStorageのkeyをCloudinaryの画像URLに設定
-            shop.shop_image.attach(
-              io: URI.open(uploaded['secure_url']), # Cloudinaryの画像URLを取得
-              filename: "#{File.basename(shop_image.original_filename, '.*')}.jpg", 
-              content_type: 'image/jpg',
-            )
-          rescue CloudinaryException => e
-            Rails.logger.error "Cloudinary upload failed: #{e.message}"
-            raise "Cloudinary upload failed: #{e.message}" # エラーを投げてトランザクションをロールバック
-          end
-        else
-          # 開発・テスト環境（ローカルストレージにそのまま保存）
-          shop.shop_image.purge if shop.persisted? && shop.shop_image.attached?
-          shop.shop_image.attach(shop_image)
-        end
+        shop.shop_image.purge if shop.shop_image.attached?
+        shop.shop_image.attach(shop_image)
       end
-      
         
     end
-    rescue ActiveRecord::RecordInvalid => e
-      Rails.logger.error("Failed to save shop: #{e.message}")
-      Rails.logger.error(e.backtrace.join("\n"))
-      false
+  rescue ActiveRecord::RecordInvalid => e
+    Rails.logger.error("Failed to save shop: #{e.message}")
+    Rails.logger.error(e.backtrace.join("\n"))
+    false
   end
 
 

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -33,3 +33,14 @@ document.addEventListener('turbo:load', () => {
   });
 });
 
+document.addEventListener('DOMContentLoaded', function() {
+  const form = document.querySelector('.new_parfait');
+  const submitButton = form.querySelector('input[type="submit"], button[type="submit"]');
+
+  form.addEventListener('submit', function(event) {
+    // フォーム送信中にボタンを無効化
+    submitButton.disabled = true;
+  });
+});
+
+

--- a/app/javascript/controllers/multiple_previews_controller.js
+++ b/app/javascript/controllers/multiple_previews_controller.js
@@ -1,23 +1,72 @@
 import { Controller } from "@hotwired/stimulus"
 
-// Connects to data-controller="multiple_previews"
+// Connects to data-controller="multiple-previews"
 export default class extends Controller {
   static targets = ["input", "preview"]
 
-  previewImage() {
-    console.log("previewImage called!")
+  // 画像圧縮を行う
+  compressImage(file, maxWidth = 1000, maxHeight = 1000, quality = 0.7) {
+    return new Promise((resolve, reject) => {
+      const img = new Image();
+      const reader = new FileReader();
 
+      reader.onload = (e) => {
+        img.src = e.target.result;
+
+        img.onload = () => {
+          const canvas = document.createElement("canvas");
+          const ctx = canvas.getContext("2d");
+
+          // 新しい画像のサイズを計算
+          const width = img.width;
+          const height = img.height;
+
+          const ratio = Math.min(maxWidth / width, maxHeight / height);
+          const newWidth = width * ratio;
+          const newHeight = height * ratio;
+
+          canvas.width = newWidth;
+          canvas.height = newHeight;
+
+          // 画像を描画
+          ctx.drawImage(img, 0, 0, newWidth, newHeight);
+
+          // 圧縮した画像をBase64として取得
+          canvas.toBlob(
+            (blob) => {
+              const compressedFile = new File([blob], file.name, {
+                type: "image/jpeg",
+                lastModified: Date.now(),
+              });
+              resolve(compressedFile);  // 圧縮されたファイルを返す
+            },
+            "image/jpeg",
+            quality
+          );
+        };
+      };
+
+      reader.readAsDataURL(file);
+    });
+  }
+
+  // 画像が選択された時の処理
+  async previewImage() {
     const input = this.inputTarget
     const preview = this.previewTarget
-    console.log("Selected files:", input.files)
-
-    preview.innerHTML = ""
+    preview.innerHTML = ""  // プレビューエリアをクリア
 
     if (input.files.length === 0) return;
 
-    Array.from(input.files).forEach((file) => {
+    // 複数の画像を処理
+    for (let i = 0; i < input.files.length; i++) {
+      const file = input.files[i];
+      
+      // 画像を圧縮
+      const compressedFile = await this.compressImage(file);
+      
+      // 圧縮後の画像をプレビュー表示
       const reader = new FileReader();
-
       reader.onload = (e) => {
         const img = document.createElement("img");
         img.src = e.target.result;
@@ -25,9 +74,14 @@ export default class extends Controller {
         img.style.marginRight = "5px";
         preview.appendChild(img);
       };
+      
+      reader.readAsDataURL(compressedFile);
 
-      reader.readAsDataURL(file);
-    });
+      // 圧縮された画像をformに追加 (Hiddenフィールドでアップロード用に送信)
+      const dataTransfer = new DataTransfer();
+      dataTransfer.items.add(compressedFile);
+      input.files = dataTransfer.files;
+    }
 
     this.previewTarget.parentElement.style.display = "";
   }

--- a/app/javascript/controllers/multiple_previews_controller.js
+++ b/app/javascript/controllers/multiple_previews_controller.js
@@ -4,85 +4,30 @@ import { Controller } from "@hotwired/stimulus"
 export default class extends Controller {
   static targets = ["input", "preview"]
 
-  // 画像圧縮を行う
-  compressImage(file, maxWidth = 1000, maxHeight = 1000, quality = 0.7) {
-    return new Promise((resolve, reject) => {
-      const img = new Image();
-      const reader = new FileReader();
-
-      reader.onload = (e) => {
-        img.src = e.target.result;
-
-        img.onload = () => {
-          const canvas = document.createElement("canvas");
-          const ctx = canvas.getContext("2d");
-
-          // 新しい画像のサイズを計算
-          const width = img.width;
-          const height = img.height;
-
-          const ratio = Math.min(maxWidth / width, maxHeight / height);
-          const newWidth = width * ratio;
-          const newHeight = height * ratio;
-
-          canvas.width = newWidth;
-          canvas.height = newHeight;
-
-          // 画像を描画
-          ctx.drawImage(img, 0, 0, newWidth, newHeight);
-
-          // 圧縮した画像をBase64として取得
-          canvas.toBlob(
-            (blob) => {
-              const compressedFile = new File([blob], file.name, {
-                type: "image/jpeg",
-                lastModified: Date.now(),
-              });
-              resolve(compressedFile);  // 圧縮されたファイルを返す
-            },
-            "image/jpeg",
-            quality
-          );
-        };
-      };
-
-      reader.readAsDataURL(file);
-    });
-  }
-
-  // 画像が選択された時の処理
-  async previewImage() {
+  previewImage() {
     const input = this.inputTarget
     const preview = this.previewTarget
-    preview.innerHTML = ""  // プレビューエリアをクリア
+    preview.innerHTML = ""  // プレビューエリアを空っぽにする
 
-    if (input.files.length === 0) return;
+    if (input.files.length === 0) return;  // ファイルがなかったら何もしない
 
-    // 複数の画像を処理
+    // えらばれたファイルをひとつずつ見る
     for (let i = 0; i < input.files.length; i++) {
       const file = input.files[i];
-      
-      // 画像を圧縮
-      const compressedFile = await this.compressImage(file);
-      
-      // 圧縮後の画像をプレビュー表示
+
       const reader = new FileReader();
       reader.onload = (e) => {
         const img = document.createElement("img");
-        img.src = e.target.result;
-        img.style.maxWidth = "200px";
-        img.style.marginRight = "5px";
-        preview.appendChild(img);
+        img.src = e.target.result;  // 読み込んだ画像データをimgにセット
+        img.style.maxWidth = "200px";  // プレビュー画像の大きさを小さめに
+        img.style.marginRight = "5px";  // 画像同士の間にすこしスペースを空ける
+        preview.appendChild(img);  // プレビューエリアに画像を追加
       };
       
-      reader.readAsDataURL(compressedFile);
-
-      // 圧縮された画像をFormDataに追加 (これで複数ファイルを保持)
-      // 今回はFormDataはサーバーへの送信時に使用しますが、プレビュー表示には必要ありません。
+      reader.readAsDataURL(file);  // ファイルを読み込む
     }
 
-    // プレビューエリアの表示
+    // プレビューエリアを見えるようにする
     this.previewTarget.parentElement.style.display = "";
   }
 }
-

--- a/app/javascript/controllers/multiple_previews_controller.js
+++ b/app/javascript/controllers/multiple_previews_controller.js
@@ -77,12 +77,12 @@ export default class extends Controller {
       
       reader.readAsDataURL(compressedFile);
 
-      // 圧縮された画像をformに追加 (Hiddenフィールドでアップロード用に送信)
-      const dataTransfer = new DataTransfer();
-      dataTransfer.items.add(compressedFile);
-      input.files = dataTransfer.files;
+      // 圧縮された画像をFormDataに追加 (これで複数ファイルを保持)
+      // 今回はFormDataはサーバーへの送信時に使用しますが、プレビュー表示には必要ありません。
     }
 
+    // プレビューエリアの表示
     this.previewTarget.parentElement.style.display = "";
   }
 }
+

--- a/app/javascript/controllers/previews_controller.js
+++ b/app/javascript/controllers/previews_controller.js
@@ -3,6 +3,7 @@ import { Controller } from "@hotwired/stimulus"
 // Connects to data-controller="previews"
 export default class extends Controller {
   static targets = ["input", "preview"]
+
   connect() {
     const preview = this.previewTarget
     const width = this.data.get('width')
@@ -19,11 +20,49 @@ export default class extends Controller {
     const width = this.data.get('width')
 
     if (files && files[0]) {
-    const reader = new FileReader()
-    reader.onload = (e) => {
-        preview.innerHTML = `<img src="${e.target.result}" style="max-width: ${width}px;">`;
-        }
-    reader.readAsDataURL(files[0])
+      const file = files[0];
+      const reader = new FileReader();
+      
+      reader.onload = (e) => {
+        const img = new Image();
+        img.onload = () => {
+          const canvas = document.createElement('canvas');
+          const ctx = canvas.getContext('2d');
+
+          const MAX_WIDTH = 800;
+          const MAX_HEIGHT = 800;
+
+          let targetWidth = img.width;
+          let targetHeight = img.height;
+
+          // 幅か高さがMAXを超えていたら縮小する（縦横比を維持）
+          if (targetWidth > MAX_WIDTH || targetHeight > MAX_HEIGHT) {
+            const widthRatio = MAX_WIDTH / targetWidth;
+            const heightRatio = MAX_HEIGHT / targetHeight;
+            const scale = Math.min(widthRatio, heightRatio);
+            targetWidth = targetWidth * scale;
+            targetHeight = targetHeight * scale;
+          }
+
+          canvas.width = targetWidth;
+          canvas.height = targetHeight;
+          ctx.drawImage(img, 0, 0, targetWidth, targetHeight);
+
+          // プレビュー用に小さく表示
+          preview.innerHTML = `<img src="${canvas.toDataURL('image/jpeg')}" style="max-width: ${width}px;">`;
+
+          // inputにリサイズ後のデータをセットする
+          canvas.toBlob((blob) => {
+            const resizedFile = new File([blob], file.name, { type: 'image/jpeg' });
+
+            const dataTransfer = new DataTransfer();
+            dataTransfer.items.add(resizedFile);
+            input.files = dataTransfer.files;
+          }, 'image/jpeg', 0.8); // 画質80%
+        };
+        img.src = e.target.result;
+      };
+      reader.readAsDataURL(file);
     }
-  }    
+  }
 }

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -6,22 +6,23 @@ class Review < ApplicationRecord
   validates :body, presence: true, length: { maximum: 500 }
 
   has_many_attached :review_images
-  validate :review_images_limit
   validates :review_images,
             content_type: { in: %i(png jpg jpeg),
             message: "有効なフォーマットではありません" },
-            size: { less_than_or_equal_to: 10.megabytes, message: "5MBを超える画像はアップロードできません" },              # ファイルサイズ
-            dimension: { width: { max: 2000 }, height: { max: 2000 } } # 画像の大きさ
+            size: { less_than_or_equal_to: 10.megabytes, message: "10MBを超える画像はアップロードできません" },              # ファイルサイズ
+            dimension: { width: { max: 4000 }, height: { max: 4100 } } # 画像の大きさ
 
+  validate :limit_review_images_count
 
   def image_as_thumbnail
     return unless review_images.content_type.in?(%w[image/jpeg image/png])
     review_images.variant(resize_to_limit: [400, 500]).processed
   end
 
-  def review_images_limit
-    if review_images.attached? && review_images.count > 5
-      errors.add(:review_images, "は5枚までアップロードできます")
+  private
+  def limit_review_images_count
+    if review_images.attached? && review_images.length > 3
+      errors.add(:review_images, "は3枚までしかアップロードできません")
     end
   end
 

--- a/app/views/parfaits/_form.html.erb
+++ b/app/views/parfaits/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with model: parfait, url: parfait.persisted? ? parfait_path(parfait) : shop_parfaits_path, local: true, class: "new_parfait mt-4" do |f| %>
+<%= form_with model: parfait, url: parfait.persisted? ? parfait_path(parfait) : shop_parfaits_path, local: true, class: "new_parfait mt-4", data: { turbo: "false" } do |f| %>
   <div class="mb-3">
     <%= f.label :パフェ名 %>
     <%= f.text_field :name, class: "form-control" %>

--- a/app/views/reviews/_form.html.erb
+++ b/app/views/reviews/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with model: review, url: review.persisted? ? review_path(review) : reviews_path, local: true, class: "new_parfait mt-4" do |f| %>
+<%= form_with model: review, url: review.persisted? ? review_path(review) : reviews_path, local: true, multiple: true, class: "new_parfait mt-4" do |f| %>
   <div class="mb-3">
     <%= f.label :タイトル %>
     <%= f.text_field :title, class: "form-control" %>

--- a/app/views/reviews/_image_form.erb
+++ b/app/views/reviews/_image_form.erb
@@ -1,6 +1,6 @@
 <div class="mb-3" data-controller="multiple-previews">
   <%= f.label :review_images, '画像' %>
-  <%= f.file_field :review_images, multiple: true, data: { "action" => "change->multiple-previews#previewImage", "multiple-previews-target" => "input" } %>
+  <%= f.file_field :review_images, multiple: true, include_hidden: false, data: { "action" => "change->multiple-previews#previewImage", "multiple-previews-target" => "input" } %>
 
   <div class="mt-2" data-multiple-previews-target="preview"></div>
 </div>

--- a/app/views/reviews/edit.html.erb
+++ b/app/views/reviews/edit.html.erb
@@ -4,7 +4,7 @@
       <h3>レビュー編集</h3>
       <h5><%= @review.parfait.shop.name %></h5>
       <h5><%= @review.parfait.name %></h5>
-      <%= form_with model: @review, local: true, class: "new_parfait mt-4" do |f| %>
+      <%= form_with model: @review, local: true, multiple: true, class: "new_parfait mt-4" do |f| %>
         <div class="mb-3">
           <%= f.label :タイトル %>
           <%= f.text_field :title, class: "form-control" %>

--- a/app/views/shops/_form.html.erb
+++ b/app/views/shops/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with model: form, html: { multipart: true }, class: "new_shop mt-4" do |f| %>
+<%= form_with model: form, data: { turbo: "false" }, class: "new_shop mt-4" do |f| %>
   <div class="mb-3">
     <%= f.label :name %>
     <%= f.text_field :name, class: "form-control" %>

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -5,7 +5,7 @@ test:
 local:
   service: Disk
   root: <%= Rails.root.join("storage") %>
-
+  cache: <%= Rails.root.join("tmp/storage") %>
 cloudinary:
   service: Cloudinary
   cloud_name: <%= ENV["CLOUDINARY_CLOUD_NAME"] %>

--- a/db/migrate/20250429135646_remove_cloudinary_public_id_from_shops.rb
+++ b/db/migrate/20250429135646_remove_cloudinary_public_id_from_shops.rb
@@ -1,0 +1,5 @@
+class RemoveCloudinaryPublicIdFromShops < ActiveRecord::Migration[7.1]
+  def change
+    remove_column :shops, :cloudinary_public_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_04_23_134832) do
+ActiveRecord::Schema[7.1].define(version: 2025_04_29_135646) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -132,7 +132,6 @@ ActiveRecord::Schema[7.1].define(version: 2025_04_23_134832) do
     t.decimal "longitude"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "cloudinary_public_id"
     t.index ["name"], name: "index_shops_on_name", unique: true
     t.index ["postal_code"], name: "index_shops_on_postal_code", unique: true
   end


### PR DESCRIPTION
## 概要
- cloudinaryにactive_strageで一元化して送れるようにした
- javascriptでhas_one_attachの画像をリサイズ＆プレビューできるようにした。
- javascriptでhas_many_attachの画像をプレビューできるようにした。

## 懸念点
- has_many_attachの方は圧縮しないでそのままの大きさで送れる程度のバリデーションにした
- has_one_attachの方はcloudinaryで二重で送られるようになっている