### PR TITLE
topページのパフェ新着情報の編集・削除権限を制限

### DIFF
--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -32,15 +32,17 @@
                           <%= link_to parfait.name, parfait_path(parfait) %>
                         </h4>
                         <% if user_signed_in? %>
-                          <div class='ms-auto d-flex'>
-                            <!-- rspecテストのためにid必要です -->
-                            <%= link_to edit_parfait_path(parfait), id: "button-edit-#{parfait.id}", class: "me-2" do %>
-                              <i class='bi bi-pencil-fill'></i> 編集
-                            <% end %>
-                            <%= link_to parfait_path(parfait), id: "button-delete-#{parfait.id}", data: { turbo_method: :delete, turbo_confirm: t('defaults.delete_confirm') } do %>
-                              <i class="bi bi-trash-fill"></i> 削除
-                            <% end %>
-                          </div>
+                          <% if current_user.own?(parfait) %>
+                            <div class='ms-auto d-flex'>
+                              <!-- rspecテストのためにid必要です -->
+                              <%= link_to edit_parfait_path(parfait), id: "button-edit-#{parfait.id}", class: "me-2" do %>
+                                <i class='bi bi-pencil-fill'></i> 編集
+                              <% end %>
+                              <%= link_to parfait_path(parfait), id: "button-delete-#{parfait.id}", data: { turbo_method: :delete, turbo_confirm: t('defaults.delete_confirm') } do %>
+                                <i class="bi bi-trash-fill"></i> 削除
+                              <% end %>
+                            </div>
+                          <% end %>  
                         <% end %>
                       </div>
                       <div>


### PR DESCRIPTION
# 概要
topページのパフェ新着情報の編集・削除権限を制限
app/views/static_pages/top.html.erb